### PR TITLE
chore: v1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v1.5.1 (Jan 13, 2020)
+
+ * chore: Switched to new `appcd.apiVersion`.
+   [(DAEMON-309)](https://jira.appcelerator.org/browse/DAEMON-309)
+ * chore: Updated dependencies.
+
 # v1.5.0 (Aug 15, 2019)
 
  * chore: Added Appc Daemon v3 to list of compatible appcd versions.

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2017-2019 by Axway, Inc.
+Copyright 2017-2020 by Axway, Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@appcd/plugin-system-info",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "The Appc Daemon plugin for detecting system info.",
   "main": "./dist/index",
   "author": "Appcelerator, Inc. <npmjs@appcelerator.com>",
@@ -16,18 +16,18 @@
     "test": "gulp test"
   },
   "dependencies": {
-    "gawk": "^4.6.4",
-    "source-map-support": "^0.5.13"
+    "gawk": "^4.7.0",
+    "source-map-support": "^0.5.16"
   },
   "devDependencies": {
-    "appcd-gulp": "^2.2.0",
+    "appcd-gulp": "^2.3.2",
     "gulp": "^4.0.2"
   },
-  "homepage": "https://github.com/appcelerator/appc-daemon-plugins/tree/master/packages/appcd-plugin-system-info",
-  "bugs": "https://github.com/appcelerator/appc-daemon-plugins/issues",
-  "repository": "https://github.com/appcelerator/appc-daemon-plugins",
+  "homepage": "https://github.com/appcelerator/appc-daemon",
+  "bugs": "https://github.com/appcelerator/appcd-plugin-system-info/issues",
+  "repository": "https://github.com/appcelerator/appcd-plugin-system-info",
   "appcd": {
-    "appcdVersion": "1.x || 2.x || 3.x",
+    "apiVersion": "1.x",
     "name": "system-info",
     "type": "external"
   },


### PR DESCRIPTION
chore: Switched to new 'appcd.apiVersion'.
chore: Updated npm deps.