### PR TITLE
v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,14 @@
+# v2.0.0 (Jan 13, 2020)
+
+ * BREAKING CHANGE: Updated to v2.x for `android`, `ios`, and `windows` plugins.
+ * chore: Switched to new `appcd.apiVersion`.
+   [(DAEMON-309)](https://jira.appcelerator.org/browse/DAEMON-309)
+ * chore: Updated dependencies.
+
 # v1.5.0 (Aug 15, 2019)
 
  * chore: Added Appc Daemon v3 to list of compatible appcd versions.
- * chore: Update dependencies.
+ * chore: Updated dependencies.
 
 # v1.4.0 (Jun 6, 2019)
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2017-2019 by Axway, Inc.
+Copyright 2017-2020 by Axway, Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@appcd/plugin-system-info",
-  "version": "1.5.0",
+  "version": "2.0.0",
   "description": "The Appc Daemon plugin for detecting system info.",
   "main": "./dist/index",
   "author": "Appcelerator, Inc. <npmjs@appcelerator.com>",
@@ -16,18 +16,18 @@
     "test": "gulp test"
   },
   "dependencies": {
-    "gawk": "^4.6.4",
-    "source-map-support": "^0.5.13"
+    "gawk": "^4.7.0",
+    "source-map-support": "^0.5.16"
   },
   "devDependencies": {
-    "appcd-gulp": "^2.2.0",
+    "appcd-gulp": "^2.3.2",
     "gulp": "^4.0.2"
   },
   "homepage": "https://github.com/appcelerator/appc-daemon-plugins/tree/master/packages/appcd-plugin-system-info",
   "bugs": "https://github.com/appcelerator/appc-daemon-plugins/issues",
   "repository": "https://github.com/appcelerator/appc-daemon-plugins",
   "appcd": {
-    "appcdVersion": "1.x || 2.x || 3.x",
+    "apiVersion": "1.x",
     "name": "system-info",
     "type": "external"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -19,13 +19,13 @@ import { isFile } from 'appcd-fs';
  * @type {Object}
  */
 const dependencies = {
-	android:            '/android/1.x/info',
+	android:            '/android/2.x/info',
 	genymotion:         '/genymotion/1.x/info',
-	ios:                '/ios/1.x/info',
+	ios:                '/ios/2.x/info',
 	jdks:               '/jdk/1.x/info',
 	'titanium/sdks':    '/titanium/1.x/sdk/list',
 	'titanium/modules': '/titanium/1.x/modules/list',
-	windows:            '/windows/1.x/info'
+	windows:            '/windows/2.x/info'
 };
 
 /**


### PR DESCRIPTION
BREAKING CHANGE: Updated to v2.x for 'android', 'ios', and 'windows' plugins.
chore: Switched to new 'appcd.apiVersion'.
chore: Updated npm deps.